### PR TITLE
Match box score: per-team game stats tabs

### DIFF
--- a/docs/superpowers/specs/2026-07-28-match-box-score-design.md
+++ b/docs/superpowers/specs/2026-07-28-match-box-score-design.md
@@ -1,0 +1,62 @@
+# Match Box Score (per-team game stats tabs) — Design
+
+**Date:** 2026-07-28 · **Owner-approved decisions inline** · **Scope:** fan app, all sports, league AND tournament match pages, current and future competitions.
+
+## Problem
+
+The match page shows individual events in Summary and the roster in Lineup, but there is no
+place to see **everyone's stats for that game** at a glance (the old app had this; FotMob's
+box score is the reference).
+
+## Decision summary (owner)
+
+1. **Hide the Lineup tab** (do not delete `match_lineup_tab.dart` — future work will bring it
+   back with players positioned on the field).
+2. Match page tabs become **Summary | \<Team 1 name\> | \<Team 2 name\>** — one tab per team,
+   each showing that team's players and their stats **for this match only**.
+3. **Row identity stays frozen** while stat columns scroll horizontally: player photo
+   (FotMob-style, initials fallback), name, jersey number pinned left.
+4. **No "see more" button** — stat columns are always horizontally swipeable, ordered
+   most-important-first.
+5. **Auto-hide empty columns**: a stat column renders only if at least one player on either
+   team recorded it in this match (consistent columns across both team tabs). If the match
+   has no recorded stats at all, show the roster rows with a "No stats recorded yet" note —
+   never a blank tab.
+6. **Default sort: best performers first** (sport's primary stat, descending). **Tapping any
+   column header sorts** by that stat, toggling desc/asc; tapping the name header sorts
+   alphabetically.
+7. Tapping a player row opens their profile (standard `openPlayerProfileById`).
+8. **Live**: tallies recompute from the existing live match-activity streams during games.
+
+## Per-sport columns (importance order, left → right)
+
+| Sport | Columns |
+|---|---|
+| Soccer / Futsal | Goals, Assists, DPL, Saves, Fouls*, Yellow, Red |
+| Basketball | PTS (derived FT + 2×2PT + 3×3PT), REB, AST, 3PM, 2PM, FTM, STL, BLK, TO, Fouls |
+| Flag Football | TD, Pass TD, REC, INT, Flag Pulls, Sacks, Fouls*, Catch % (derived; only when targets exist) |
+
+*Owner addition ("fun to have"): a Fouls column for EVERY sport whose match capture
+records foul events — verify per sport against the stats-engine event types; where a
+sport never records fouls the column is simply not defined (auto-hide covers partial
+cases regardless).
+
+## Architecture
+
+- **One shared widget** `TeamBoxScoreTab` (new, `lib/match_tabs/team_box_score_tab.dart`)
+  consumed by BOTH `tournament_match_detail.dart` and `league_match_detail.dart` — no
+  per-surface forks. Inputs: the team's roster (players w/ photo, number), the match's
+  per-player tallies, the sport's column defs, `onOpenPlayer`.
+- **Pure column/tally layer** (`lib/match_tabs/box_score_columns.dart`): per-sport column
+  definitions + a `visibleColumns(tallies)` filter (auto-hide) + sort helper. Reuses the
+  existing single-match tally computation that already powers Match Leaders — extended where
+  a sport records stats the leaders strip doesn't surface (cards, fouls, turnovers…).
+- Frozen-left + horizontal-scroll built the same way the repo's existing sticky tables do.
+- Theme-safe light+dark; Builder-wrapped rows (itemBuilder staleness rule); team-name tabs
+  rely on the existing scrollable TabBar.
+
+## Out of scope (explicit)
+
+- Lineup-on-field with positioned player heads (future epic, noted in backlog).
+- Season/tournament totals (already covered by Player Stats tabs).
+- Manager app changes: none needed — all data already recorded per match.

--- a/integration_test/tournament_bleed_test.dart
+++ b/integration_test/tournament_bleed_test.dart
@@ -1,0 +1,91 @@
+// On-device diagnostic for the owner-reported cross-tournament data bleed:
+// opens the three real tournaments' detail pages back-to-back against the
+// LIVE database (public read) and asserts no tournament renders another's
+// team names or title anywhere in its Table / Player Stats / Teams tabs.
+//
+// Run: C:\src\flutter\bin\flutter.bat test integration_test -d emulator-5554
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_config/flutter_config.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_sports_flutter/firebase_options.dart';
+import 'package:infinite_sports_flutter/tournamentdetail.dart';
+import 'package:integration_test/integration_test.dart';
+
+const basketNames = {
+  'Akkad', 'Ashur', 'Babylon', 'ishtar', 'Lamassu', 'Nimrod', 'Nineveh',
+  'Urmia', '3vs3 basketballl',
+};
+const calNames = {
+  'Active FC', 'AFC San Jose Elite', 'AFC San Jose Rising Stars',
+  'Club Assyria', 'FC Babylon', 'Westcoast Winged Bulls',
+  'California State Assyrian Tournament 2026',
+};
+const testNames = {
+  'Bears', 'Bulls', 'Cobras', 'Comets', 'Eagles', 'Falcons', 'Foxes',
+  'Hawks', 'Kings', 'Lions', 'Panthers', 'Rovers', 'Sharks', 'Storm',
+  'Tigers', 'Wolves', 'Test Tournament 2026',
+};
+
+Set<String> visibleTexts(WidgetTester tester) => tester
+    .widgetList<Text>(find.byType(Text))
+    .map((w) => w.data ?? '')
+    .where((s) => s.isNotEmpty)
+    .toSet();
+
+Future<void> settleReal(WidgetTester tester, int seconds) async {
+  for (var i = 0; i < seconds * 4; i++) {
+    await Future<void>.delayed(const Duration(milliseconds: 250));
+    await tester.pump();
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('tournament pages never render another tournament\'s data',
+      (tester) async {
+    await FlutterConfig.loadEnvVariables();
+    await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform);
+
+    Future<Set<String>> openAndCollect(String id, String name) async {
+      await tester.pumpWidget(MaterialApp(
+          home: TournamentDetailPage(tournamentId: id, tournamentName: name)));
+      await settleReal(tester, 6);
+      final all = <String>{...visibleTexts(tester)};
+      for (final tab in ['Table', 'Player Stats', 'Teams', 'Predict']) {
+        final f = find.text(tab);
+        if (f.evaluate().isEmpty) continue;
+        await tester.tap(f.first, warnIfMissed: false);
+        await settleReal(tester, 3);
+        all.addAll(visibleTexts(tester));
+      }
+      return all;
+    }
+
+    // Same browsing order the owner described: basketball and California
+    // first, then the Test tournament that showed their data.
+    final basket = await openAndCollect('basket123', '3vs3 basketballl');
+    final cal = await openAndCollect(
+        'ca_state_assyrian_2026', 'California State Assyrian Tournament 2026');
+    final test = await openAndCollect(
+        'test-tournament-2026', 'Test Tournament 2026');
+
+    debugPrint('=== BLEED REPORT ===');
+    debugPrint('basket page foreign texts: '
+        '${basket.intersection(calNames)} ${basket.intersection(testNames)}');
+    debugPrint('california page foreign texts: '
+        '${cal.intersection(basketNames)} ${cal.intersection(testNames)}');
+    debugPrint('test page foreign texts: '
+        '${test.intersection(basketNames)} ${test.intersection(calNames)}');
+    debugPrint('=== END BLEED REPORT ===');
+
+    expect(test.intersection(calNames), isEmpty,
+        reason: 'California data rendered inside Test Tournament');
+    expect(test.intersection(basketNames), isEmpty,
+        reason: 'Basketball data rendered inside Test Tournament');
+    expect(cal.intersection(basketNames), isEmpty,
+        reason: 'Basketball data rendered inside California');
+  });
+}

--- a/lib/league_detail_page.dart
+++ b/lib/league_detail_page.dart
@@ -115,6 +115,39 @@ class _LeagueDetailPageState extends State<LeagueDetailPage>
   @override
   void initState() {
     super.initState();
+    _subscribeAll();
+  }
+
+  /// Cross-competition bleed fix (owner bug report 2026-07-30, tournament
+  /// twin in tournamentdetail.dart): all streams here bake widget.sport +
+  /// widget.season in at subscribe time, so an element reused with a
+  /// DIFFERENT season kept rendering (and live-updating) the previous
+  /// season. On an identity change: drop every subscription and every piece
+  /// of loaded state back to the skeleton seeds, then resubscribe.
+  @override
+  void didUpdateWidget(covariant LeagueDetailPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.sport == widget.sport && oldWidget.season == widget.season) {
+      return;
+    }
+    _gamesSub?.cancel();
+    _standingsSub?.cancel();
+    _rostersSub?.cancel();
+    _playoffsSub?.cancel();
+    _configSub?.cancel();
+    setState(() {
+      _matches = null;
+      _standings = null;
+      _rosters = null;
+      _playoffs = null;
+      _playoffsLoaded = false;
+      _logos = {};
+      _startHour = 0;
+    });
+    _subscribeAll();
+  }
+
+  void _subscribeAll() {
     // First paint speed (P2.1): the 4 streams subscribe IMMEDIATELY with
     // default display seeds (startHour 0, no logos) instead of waiting two
     // round trips; the seeds re-apply below when they arrive.

--- a/lib/league_match_detail.dart
+++ b/lib/league_match_detail.dart
@@ -433,14 +433,13 @@ class _LeagueMatchDetailPageState extends State<LeagueMatchDetailPage> {
                 // Summary + per-team box score tabs (parity with the
                 // tournament match page).
                 bottom: TabBar(
-                  // Scrollable: team names can be long (spec — team tabs
-                  // rely on the scrollable TabBar).
-                  isScrollable: true,
-                  tabAlignment: TabAlignment.center,
+                  // Owner feedback: the three tabs spread evenly across the
+                  // full width (scrollable clustered them in the center);
+                  // long team names scale down to fit their third.
                   tabs: [
                     const Tab(text: 'Summary'),
-                    Tab(text: team1?.name ?? match.team1Id ?? 'Team 1'),
-                    Tab(text: team2?.name ?? match.team2Id ?? 'Team 2'),
+                    teamNameTab(team1?.name ?? match.team1Id ?? 'Team 1'),
+                    teamNameTab(team2?.name ?? match.team2Id ?? 'Team 2'),
                   ],
                   labelColor: TournamentColors.headerForeground(context),
                   unselectedLabelColor:

--- a/lib/league_match_detail.dart
+++ b/lib/league_match_detail.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:infinite_sports_flutter/league_team_detail.dart';
+import 'package:infinite_sports_flutter/match_tabs/box_score_columns.dart';
+import 'package:infinite_sports_flutter/match_tabs/team_box_score_tab.dart';
 import 'package:infinite_sports_flutter/misc/goal_toast.dart';
 import 'package:infinite_sports_flutter/misc/league_adapters.dart';
 import 'package:infinite_sports_flutter/misc/league_service.dart';
@@ -17,7 +19,6 @@ import 'package:infinite_sports_flutter/model/tournamentmatch.dart';
 import 'package:infinite_sports_flutter/model/tournamentplayer.dart';
 import 'package:infinite_sports_flutter/model/tournamentteam.dart';
 import 'package:infinite_sports_flutter/tournament_tabs/match_facts_tab.dart';
-import 'package:infinite_sports_flutter/tournament_tabs/match_lineup_tab.dart';
 import 'package:infinite_sports_flutter/widgets/live_clock.dart';
 import 'package:infinite_sports_flutter/widgets/score_text.dart';
 import 'package:infinite_sports_flutter/widgets/skeleton.dart';
@@ -64,10 +65,15 @@ class _LeagueMatchDetailPageState extends State<LeagueMatchDetailPage> {
   PredictionConfig? _predictionConfig;
   StreamSubscription<PredictionConfig>? _configSub;
 
+  // Box-score tallies memoized off the live match (tournamentdetail.dart
+  // lag-fix rule): recomputed only when a stream event lands, never in build.
+  Map<String, MatchPlayerTally> _matchTallies = const {};
+
   @override
   void initState() {
     super.initState();
     _match = widget.initialMatch;
+    if (_match != null) _matchTallies = singleMatchPlayerTallies(_match!);
     // First paint speed (P2.1): subscribe immediately with default seeds;
     // startHour (kick-off fallback text) re-applies via re-subscribe and
     // logos apply at build time when they arrive.
@@ -115,7 +121,10 @@ class _LeagueMatchDetailPageState extends State<LeagueMatchDetailPage> {
         _showGoalToast(m, m.team2Id ?? '');
       }
     }
-    setState(() => _match = m);
+    setState(() {
+      _match = m;
+      _matchTallies = singleMatchPlayerTallies(m);
+    });
   }
 
   void _showGoalToast(TournamentMatch m, String teamName) {
@@ -366,9 +375,12 @@ class _LeagueMatchDetailPageState extends State<LeagueMatchDetailPage> {
     final team2Players = match.team2Id != null
         ? (_rosters[match.team2Id] ?? <TournamentPlayer>[])
         : <TournamentPlayer>[];
+    // Per-team box score tabs (Match Box Score spec): the Lineup tab is
+    // hidden — match_lineup_tab.dart survives for the future on-field view.
+    final boxScoreColumns = boxScoreColumnsFor(widget.sport);
 
     return DefaultTabController(
-      length: 2,
+      length: 3,
       child: Scaffold(
         body: NestedScrollView(
           headerSliverBuilder: (context, innerBoxIsScrolled) {
@@ -418,11 +430,17 @@ class _LeagueMatchDetailPageState extends State<LeagueMatchDetailPage> {
                   background:
                       _buildScoreboardHeader(context, match, team1, team2),
                 ),
-                // Facts + Lineup tabs (parity with the tournament match page).
+                // Summary + per-team box score tabs (parity with the
+                // tournament match page).
                 bottom: TabBar(
-                  tabs: const [
-                    Tab(text: 'Summary'),
-                    Tab(text: 'Lineup'),
+                  // Scrollable: team names can be long (spec — team tabs
+                  // rely on the scrollable TabBar).
+                  isScrollable: true,
+                  tabAlignment: TabAlignment.center,
+                  tabs: [
+                    const Tab(text: 'Summary'),
+                    Tab(text: team1?.name ?? match.team1Id ?? 'Team 1'),
+                    Tab(text: team2?.name ?? match.team2Id ?? 'Team 2'),
                   ],
                   labelColor: TournamentColors.headerForeground(context),
                   unselectedLabelColor:
@@ -459,15 +477,18 @@ class _LeagueMatchDetailPageState extends State<LeagueMatchDetailPage> {
                 leaderCategories: leagueMatchLeaderCategories(widget.sport),
                 leagueSportKey: widget.sport,
               ),
-              // Lineup tab (Task 1): the same rosters already streamed for
-              // the Facts tab's Match Leaders / timeline name resolution.
-              MatchLineupTab(
-                match: match,
-                team1: team1,
-                team2: team2,
-                team1Players: team1Players,
-                team2Players: team2Players,
-                sport: widget.sport,
+              // Per-team box scores: the same rosters already streamed for
+              // the Facts tab's Match Leaders / timeline name resolution,
+              // tallied from the same live match activity.
+              TeamBoxScoreTab(
+                roster: team1Players,
+                tallies: _matchTallies,
+                columns: boxScoreColumns,
+              ),
+              TeamBoxScoreTab(
+                roster: team2Players,
+                tallies: _matchTallies,
+                columns: boxScoreColumns,
               ),
             ],
           ),

--- a/lib/league_tabs/league_player_stats_tab.dart
+++ b/lib/league_tabs/league_player_stats_tab.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:infinite_sports_flutter/misc/league_adapters.dart';
+import 'package:infinite_sports_flutter/misc/league_stat_categories.dart';
 import 'package:infinite_sports_flutter/model/tournamentplayer.dart';
 import 'package:infinite_sports_flutter/model/tournamentteam.dart';
 import 'package:infinite_sports_flutter/profile/open_player_profile.dart';
@@ -49,53 +50,8 @@ class _LeaguePlayerStatsTabState extends State<LeaguePlayerStatsTab> {
     }
   }
 
-  /// label → statByName key → statIconAsset key ('' = no icon, matching
-  /// the tournament tab's iconless Clean Sheets). Per-sport, fan-side by
-  /// convention (see top_stats.dart header) — the config twin carries no
-  /// leaderboard defs. An optional 'suffix' renders after each value
-  /// ('%' for FF Catch %).
-  static const Map<String, List<Map<String, String>>> _categoriesBySport = {
-    'Futsal': [
-      {'label': 'Top Scorer', 'stat': 'goals', 'icon': 'goal'},
-      {'label': 'Assists', 'stat': 'assists', 'icon': 'assist'},
-      {'label': 'Saves', 'stat': 'saves', 'icon': 'save'},
-      {'label': 'Defensive Plays (DPL)', 'stat': 'dpl', 'icon': 'dpl'},
-      {'label': 'Clean Sheets', 'stat': 'cleanSheets', 'icon': ''},
-      {'label': 'Yellow Cards', 'stat': 'yellowCards', 'icon': 'yellow'},
-      {'label': 'Red Cards', 'stat': 'redCards', 'icon': 'red'},
-    ],
-    // L6.2 Task 4: the full individual-stat set, in the owner's order. Every
-    // category here is a badge sport (isBadgeLeagueSport('Basketball')), so
-    // _categoryIcon below resolves the gold bball_*.png badge via
-    // leagueStatIcon(stat) regardless of the 'icon' field — left blank.
-    'Basketball': [
-      {'label': 'Points', 'stat': 'points', 'icon': ''},
-      {'label': '3-Pointers', 'stat': 'threePointers', 'icon': ''},
-      {'label': '2-Pointers', 'stat': 'twoPointers', 'icon': ''},
-      {'label': 'Free Throws Made', 'stat': 'freeThrows', 'icon': ''},
-      {'label': 'Rebounds', 'stat': 'rebounds', 'icon': ''},
-      {'label': 'Assists', 'stat': 'assists', 'icon': ''},
-      {'label': 'Steals', 'stat': 'steals', 'icon': ''},
-      {'label': 'Blocks', 'stat': 'blocks', 'icon': ''},
-      {'label': 'Turnovers', 'stat': 'turnovers', 'icon': ''},
-      {'label': 'Fouls', 'stat': 'fouls', 'icon': ''},
-    ],
-    'Flag Football': [
-      {'label': 'Touchdowns', 'stat': 'touchdowns', 'icon': ''},
-      {'label': 'Receptions', 'stat': 'receptions', 'icon': ''},
-      // L6.1: derived REC/(REC+RECMiss), gated to >=3 targets in the
-      // adapter so tiny samples never reach the board.
-      {'label': 'Catch %', 'stat': 'catchPercentage', 'icon': '',
-        'suffix': '%'},
-      {'label': 'Pass TDs', 'stat': 'passTouchdowns', 'icon': ''},
-      {'label': 'Interceptions', 'stat': 'interceptions', 'icon': ''},
-      {'label': 'Flag Pulls', 'stat': 'flagPulls', 'icon': ''},
-      {'label': 'Sacks', 'stat': 'sacks', 'icon': ''},
-    ],
-  };
-
   List<Map<String, String>> get _categories =>
-      _categoriesBySport[widget.sport] ?? _categoriesBySport['Futsal']!;
+      leagueStatCategories(widget.sport);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/league_team_detail.dart
+++ b/lib/league_team_detail.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:infinite_sports_flutter/league_match_detail.dart';
 import 'package:infinite_sports_flutter/misc/league_adapters.dart';
+import 'package:infinite_sports_flutter/misc/league_stat_categories.dart';
 import 'package:infinite_sports_flutter/misc/league_form.dart';
 import 'package:infinite_sports_flutter/misc/league_service.dart';
 import 'package:infinite_sports_flutter/misc/notification_topics.dart';
@@ -217,6 +218,7 @@ class _LeagueTeamDetailPageState extends State<LeagueTeamDetailPage>
               onPlayerTap: _openPlayer,
             ),
             LeagueTeamStatsTab(
+              sport: widget.sport,
               roster: roster,
               rosterLoaded: _rosters != null,
               onPlayerTap: _openPlayer,
@@ -701,12 +703,17 @@ class LeagueTeamSquadTab extends StatelessWidget {
 /// Stats (tournament-team-page structure): expandable leader cards per stat
 /// category, computed from THIS season's roster totals (season-scoped).
 class LeagueTeamStatsTab extends StatefulWidget {
+  /// REQUIRED: the categories rendered are per-sport. A missing sport made
+  /// this tab hunt for futsal keys on every league (owner report, PR #11 —
+  /// basketball teams showed "No stats recorded yet" despite real stats).
+  final String sport;
   final List<TournamentPlayer> roster;
   final bool rosterLoaded;
   final void Function(TournamentPlayer) onPlayerTap;
 
   const LeagueTeamStatsTab({
     super.key,
+    required this.sport,
     required this.roster,
     required this.rosterLoaded,
     required this.onPlayerTap,
@@ -717,19 +724,6 @@ class LeagueTeamStatsTab extends StatefulWidget {
 }
 
 class _LeagueTeamStatsTabState extends State<LeagueTeamStatsTab> {
-  /// label → statByName key → statIconAsset key — the EXACT icon treatment
-  /// of the league Player Stats tab (league_player_stats_tab.dart, P2.2
-  /// owner item 3); '' = no icon, matching its iconless Clean Sheets.
-  static const _categories = [
-    {'label': 'Goals', 'stat': 'goals', 'icon': 'goal'},
-    {'label': 'Assists', 'stat': 'assists', 'icon': 'assist'},
-    {'label': 'Saves', 'stat': 'saves', 'icon': 'save'},
-    {'label': 'Defensive Plays (DPL)', 'stat': 'dpl', 'icon': 'dpl'},
-    {'label': 'Clean Sheets', 'stat': 'cleanSheets', 'icon': ''},
-    {'label': 'Yellow Cards', 'stat': 'yellowCards', 'icon': 'yellow'},
-    {'label': 'Red Cards', 'stat': 'redCards', 'icon': 'red'},
-  ];
-
   final Set<String> _expandedStats = {};
 
   @override
@@ -756,7 +750,8 @@ class _LeagueTeamStatsTabState extends State<LeagueTeamStatsTab> {
     }
 
     final cards = <Widget>[];
-    for (final cat in _categories) {
+    for (final cat in leagueStatCategories(widget.sport,
+        forTeamPage: true)) {
       final label = cat['label']!;
       final stat = cat['stat']!;
       final icon = cat['icon']!;

--- a/lib/match_tabs/box_score_columns.dart
+++ b/lib/match_tabs/box_score_columns.dart
@@ -1,0 +1,168 @@
+// Pure column/sort layer for the per-team Match Box Score tabs (Match Box
+// Score spec, 2026-07-28). No Flutter imports — unit-tested directly.
+//
+// Column sets are importance-ordered per the owner's spec table. A Fouls
+// column exists only for sports whose match capture records foul events:
+// soccer/futsal ('Foul'/'foul') and basketball ('Foul') do; flag football
+// has no foul event anywhere in its LeagueSportConfig, so it defines none.
+
+import 'package:infinite_sports_flutter/misc/single_match_tallies.dart';
+import 'package:infinite_sports_flutter/model/tournamentplayer.dart';
+
+/// One box-score stat column. [valueOf] reads a player's single-match tally
+/// (null tally = player with no recorded events this match). A null VALUE
+/// means "no data" (rendered as a dash) — only Catch % produces one, for
+/// players without targets.
+class BoxScoreColumn {
+  final String key;
+
+  /// Short header label ('PTS', 'Pass TD').
+  final String label;
+
+  final int? Function(MatchPlayerTally? t) valueOf;
+
+  /// Rendered after the value ('%' for Catch %).
+  final String suffix;
+
+  const BoxScoreColumn({
+    required this.key,
+    required this.label,
+    required this.valueOf,
+    this.suffix = '',
+  });
+}
+
+int _count(MatchPlayerTally? t, String key) => t?.counts[key] ?? 0;
+
+/// Basketball PTS derived from the made-shot buckets: FT + 2×2PT + 3×3PT.
+int _points(MatchPlayerTally? t) =>
+    _count(t, 'freeThrows') +
+    2 * _count(t, 'twoPointers') +
+    3 * _count(t, 'threePointers');
+
+/// FF Catch % — UNGATED, unlike Match Leaders' >=3-target gate: the box
+/// score shows a player's real rate whenever they have targets, null (a
+/// dash) when they have none.
+int? _catchPct(MatchPlayerTally? t) =>
+    catchPercentage(_count(t, 'receptions'), _count(t, 'recMisses'));
+
+final List<BoxScoreColumn> _soccerFutsalColumns = [
+  BoxScoreColumn(key: 'goals', label: 'Goals', valueOf: (t) => t?.goals ?? 0),
+  BoxScoreColumn(
+      key: 'assists', label: 'Assists', valueOf: (t) => t?.assists ?? 0),
+  BoxScoreColumn(key: 'dpl', label: 'DPL', valueOf: (t) => t?.dpl ?? 0),
+  BoxScoreColumn(key: 'saves', label: 'Saves', valueOf: (t) => t?.saves ?? 0),
+  BoxScoreColumn(
+      key: 'fouls', label: 'Fouls', valueOf: (t) => _count(t, 'fouls')),
+  BoxScoreColumn(
+      key: 'yellowCards',
+      label: 'Yellow',
+      valueOf: (t) => _count(t, 'yellowCards')),
+  BoxScoreColumn(
+      key: 'redCards', label: 'Red', valueOf: (t) => _count(t, 'redCards')),
+];
+
+final List<BoxScoreColumn> _basketballColumns = [
+  BoxScoreColumn(key: 'points', label: 'PTS', valueOf: _points),
+  BoxScoreColumn(
+      key: 'rebounds', label: 'REB', valueOf: (t) => _count(t, 'rebounds')),
+  BoxScoreColumn(key: 'assists', label: 'AST', valueOf: (t) => t?.assists ?? 0),
+  BoxScoreColumn(
+      key: 'threePointers',
+      label: '3PM',
+      valueOf: (t) => _count(t, 'threePointers')),
+  BoxScoreColumn(
+      key: 'twoPointers',
+      label: '2PM',
+      valueOf: (t) => _count(t, 'twoPointers')),
+  BoxScoreColumn(
+      key: 'freeThrows', label: 'FTM', valueOf: (t) => _count(t, 'freeThrows')),
+  BoxScoreColumn(
+      key: 'steals', label: 'STL', valueOf: (t) => _count(t, 'steals')),
+  BoxScoreColumn(
+      key: 'blocks', label: 'BLK', valueOf: (t) => _count(t, 'blocks')),
+  BoxScoreColumn(
+      key: 'turnovers', label: 'TO', valueOf: (t) => _count(t, 'turnovers')),
+  BoxScoreColumn(
+      key: 'fouls', label: 'Fouls', valueOf: (t) => _count(t, 'fouls')),
+];
+
+final List<BoxScoreColumn> _flagFootballColumns = [
+  BoxScoreColumn(
+      key: 'touchdowns', label: 'TD', valueOf: (t) => _count(t, 'touchdowns')),
+  BoxScoreColumn(
+      key: 'passTouchdowns',
+      label: 'Pass TD',
+      valueOf: (t) => _count(t, 'passTouchdowns')),
+  BoxScoreColumn(
+      key: 'receptions', label: 'REC', valueOf: (t) => _count(t, 'receptions')),
+  BoxScoreColumn(
+      key: 'interceptions',
+      label: 'INT',
+      valueOf: (t) => _count(t, 'interceptions')),
+  BoxScoreColumn(
+      key: 'flagPulls',
+      label: 'Flag Pulls',
+      valueOf: (t) => _count(t, 'flagPulls')),
+  BoxScoreColumn(key: 'sacks', label: 'Sacks', valueOf: (t) => _count(t, 'sacks')),
+  BoxScoreColumn(
+      key: 'catchPercentage',
+      label: 'Catch %',
+      valueOf: _catchPct,
+      suffix: '%'),
+];
+
+/// The sport's full column defs, importance-ordered (first = primary stat =
+/// default sort). Returns the SAME list instance per sport so widget-level
+/// identity caching works. Unknown sports fall back to the soccer/futsal
+/// set (the leagueMatchLeaderCategories convention).
+List<BoxScoreColumn> boxScoreColumnsFor(String sport) {
+  switch (sport) {
+    case 'Basketball':
+      return _basketballColumns;
+    case 'Flag Football':
+      return _flagFootballColumns;
+    default: // Soccer / Futsal
+      return _soccerFutsalColumns;
+  }
+}
+
+/// Auto-hide filter: a column renders only if at least one player in the
+/// match has a non-null, non-zero value. Callers pass the WHOLE match's
+/// tallies (both teams) so the two team tabs always show the same columns.
+List<BoxScoreColumn> visibleColumns(
+    List<BoxScoreColumn> columns, Iterable<MatchPlayerTally> tallies) {
+  return columns
+      .where((c) => tallies.any((t) {
+            final v = c.valueOf(t);
+            return v != null && v != 0;
+          }))
+      .toList();
+}
+
+/// Sorted copy of [roster] for the box score. [column] null = alphabetical
+/// ([ascending] true = A-Z). For stat columns, [ascending] false = best
+/// first (the default); null values ("no data") sink below every number,
+/// and exact ties always break A-Z so the order is deterministic.
+List<TournamentPlayer> sortedBoxScoreRows(
+  List<TournamentPlayer> roster,
+  Map<String, MatchPlayerTally> tallies, {
+  BoxScoreColumn? column,
+  required bool ascending,
+}) {
+  int byName(TournamentPlayer a, TournamentPlayer b) =>
+      a.name.toLowerCase().compareTo(b.name.toLowerCase());
+  final out = [...roster];
+  out.sort((a, b) {
+    if (column == null) {
+      final cmp = byName(a, b);
+      return ascending ? cmp : -cmp;
+    }
+    final av = column.valueOf(tallies[a.name]) ?? -1;
+    final bv = column.valueOf(tallies[b.name]) ?? -1;
+    final cmp = av.compareTo(bv);
+    if (cmp != 0) return ascending ? cmp : -cmp;
+    return byName(a, b);
+  });
+  return out;
+}

--- a/lib/match_tabs/team_box_score_tab.dart
+++ b/lib/match_tabs/team_box_score_tab.dart
@@ -368,3 +368,14 @@ class _TeamBoxScoreTabState extends State<TeamBoxScoreTab> {
     );
   }
 }
+
+/// Match-page tab for a team name: the TabBar gives each of the three tabs
+/// an equal share of the full width (owner feedback — no center-clustered
+/// scrollable strip), and long team names scale down to one fitting line
+/// rather than wrapping or truncating.
+Tab teamNameTab(String name) => Tab(
+      child: FittedBox(
+        fit: BoxFit.scaleDown,
+        child: Text(name, maxLines: 1),
+      ),
+    );

--- a/lib/match_tabs/team_box_score_tab.dart
+++ b/lib/match_tabs/team_box_score_tab.dart
@@ -1,0 +1,370 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:infinite_sports_flutter/match_tabs/box_score_columns.dart';
+import 'package:infinite_sports_flutter/misc/single_match_tallies.dart';
+import 'package:infinite_sports_flutter/model/tournamentplayer.dart';
+import 'package:infinite_sports_flutter/profile/open_player_profile.dart';
+
+/// Per-team box score (Match Box Score spec, 2026-07-28) — one tab per team
+/// on BOTH match pages, showing that team's players and their stats for
+/// THIS match only. Row identity (photo/name/number) stays frozen on the
+/// left while stat columns swipe horizontally; both panes live in the same
+/// vertical scroll view, so rows align without controller syncing.
+class TeamBoxScoreTab extends StatefulWidget {
+  final List<TournamentPlayer> roster;
+
+  /// WHOLE-match per-player tallies (both teams, keyed by player name) —
+  /// the auto-hide filter must see both teams so the two team tabs always
+  /// render the same column set.
+  final Map<String, MatchPlayerTally> tallies;
+
+  /// The sport's full column defs (pre-auto-hide), from [boxScoreColumnsFor].
+  final List<BoxScoreColumn> columns;
+
+  /// Test seam (insiders_leaderboard_page convention): replaces
+  /// [openPlayerProfileById] so widget tests stay Firebase-free.
+  final Future<void> Function(BuildContext context,
+      {String? uid, required String name})? openProfileOverride;
+
+  const TeamBoxScoreTab({
+    super.key,
+    required this.roster,
+    required this.tallies,
+    required this.columns,
+    this.openProfileOverride,
+  });
+
+  @override
+  State<TeamBoxScoreTab> createState() => _TeamBoxScoreTabState();
+}
+
+class _TeamBoxScoreTabState extends State<TeamBoxScoreTab> {
+  static const double _rowHeight = 44;
+  static const double _headerHeight = 36;
+  static const double _identityWidth = 168;
+
+  /// null = default sort (primary stat, best first); 'name' = alphabetical.
+  String? _sortKey;
+  bool _ascending = false;
+
+  // Visible columns + row order are cached until the live match data (new
+  // tallies/roster instances) or the sort state changes — never recomputed
+  // per frame in build (the tournamentdetail.dart lag-fix rule).
+  List<BoxScoreColumn>? _visible;
+  List<TournamentPlayer>? _rows;
+
+  @override
+  void didUpdateWidget(TeamBoxScoreTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!identical(oldWidget.tallies, widget.tallies) ||
+        !identical(oldWidget.columns, widget.columns) ||
+        !identical(oldWidget.roster, widget.roster)) {
+      _visible = null;
+      _rows = null;
+    }
+  }
+
+  List<BoxScoreColumn> get _visibleColumns =>
+      _visible ??= visibleColumns(widget.columns, widget.tallies.values);
+
+  /// The header currently driving the sort ('name' when the match has no
+  /// visible stat columns — the empty state lists the roster A-Z).
+  String get _activeKey =>
+      _sortKey ??
+      (_visibleColumns.isEmpty ? 'name' : _visibleColumns.first.key);
+
+  BoxScoreColumn? get _sortColumn {
+    if (_activeKey == 'name') return null;
+    final cols = _visibleColumns;
+    return cols.firstWhere((c) => c.key == _activeKey,
+        orElse: () => cols.first);
+  }
+
+  List<TournamentPlayer> get _sortedRows => _rows ??= sortedBoxScoreRows(
+        widget.roster,
+        widget.tallies,
+        column: _sortColumn,
+        // Empty state has no headers to tap — fixed A-Z.
+        ascending: _visibleColumns.isEmpty ? true : _ascending,
+      );
+
+  void _onHeaderTap(String key) {
+    setState(() {
+      if (_activeKey == key) {
+        _ascending = !_ascending;
+      } else {
+        _sortKey = key;
+        // Stats open best-first (desc); names open A-Z (asc).
+        _ascending = key == 'name';
+      }
+      _rows = null;
+    });
+  }
+
+  void _openProfile(BuildContext context, TournamentPlayer p) {
+    final open = widget.openProfileOverride ?? openPlayerProfileById;
+    open(context, uid: p.uid, name: p.name);
+  }
+
+  double _columnWidth(BoxScoreColumn c) =>
+      c.label.length <= 3 ? 48 : 24.0 + c.label.length * 8;
+
+  String _initials(String name) {
+    final parts =
+        name.trim().split(RegExp(r'\s+')).where((w) => w.isNotEmpty).toList();
+    if (parts.isEmpty) return '?';
+    final first = parts.first[0];
+    final last = parts.length > 1 ? parts.last[0] : '';
+    return (first + last).toUpperCase();
+  }
+
+  /// FotMob-style row avatar: roster photo when present, initials fallback
+  /// (league lineups carry no player photos).
+  Widget _avatar(BuildContext context, TournamentPlayer p) {
+    final scheme = Theme.of(context).colorScheme;
+    final initials = Text(
+      _initials(p.name),
+      style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.bold,
+          color: scheme.onSurfaceVariant),
+    );
+    final url = p.photoUrl;
+    if (url == null || url.isEmpty) {
+      return CircleAvatar(
+        radius: 14,
+        backgroundColor: scheme.surfaceContainerHighest,
+        child: initials,
+      );
+    }
+    return CircleAvatar(
+      radius: 14,
+      backgroundColor: scheme.surfaceContainerHighest,
+      foregroundImage: CachedNetworkImageProvider(url),
+      onForegroundImageError: (_, __) {},
+      child: initials,
+    );
+  }
+
+  Widget _sortIndicator(BuildContext context, String key) {
+    if (_activeKey != key) return const SizedBox.shrink();
+    return Icon(
+      _ascending ? Icons.arrow_drop_up : Icons.arrow_drop_down,
+      size: 16,
+      color: Theme.of(context).colorScheme.primary,
+    );
+  }
+
+  Widget _nameHeader(BuildContext context) {
+    final muted =
+        Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6);
+    return InkWell(
+      onTap: () => _onHeaderTap('name'),
+      child: SizedBox(
+        height: _headerHeight,
+        child: Padding(
+          padding: const EdgeInsets.only(left: 12),
+          child: Row(
+            children: [
+              Text('Player',
+                  style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.bold,
+                      color: muted)),
+              _sortIndicator(context, 'name'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _statHeader(BuildContext context, BoxScoreColumn c) {
+    final muted =
+        Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6);
+    return InkWell(
+      onTap: () => _onHeaderTap(c.key),
+      child: SizedBox(
+        width: _columnWidth(c),
+        height: _headerHeight,
+        child: Center(
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(c.label,
+                    style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.bold,
+                        color: muted)),
+                _sortIndicator(context, c.key),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// Frozen-left cell: photo, name, jersey number. Names stay undecorated —
+  /// tappable names are never underlined (owner style rule).
+  Widget _identityRow(BuildContext context, TournamentPlayer p) {
+    final scheme = Theme.of(context).colorScheme;
+    return InkWell(
+      onTap: () => _openProfile(context, p),
+      child: SizedBox(
+        height: _rowHeight,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            children: [
+              _avatar(context, p),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  p.name,
+                  style:
+                      const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              if ((p.number ?? '').isNotEmpty) ...[
+                const SizedBox(width: 4),
+                Text('#${p.number}',
+                    style: TextStyle(
+                        fontSize: 11,
+                        color: scheme.onSurface.withValues(alpha: 0.5))),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _statRow(
+      BuildContext context, TournamentPlayer p, List<BoxScoreColumn> visible) {
+    final scheme = Theme.of(context).colorScheme;
+    final t = widget.tallies[p.name];
+    return InkWell(
+      onTap: () => _openProfile(context, p),
+      child: SizedBox(
+        height: _rowHeight,
+        child: Row(
+          children: [
+            for (final c in visible)
+              SizedBox(
+                width: _columnWidth(c),
+                child: Center(
+                  child: Builder(builder: (context) {
+                    final v = c.valueOf(t);
+                    final has = v != null && v != 0;
+                    return Text(
+                      v == null ? '-' : '$v${c.suffix}',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: has ? FontWeight.w600 : FontWeight.w400,
+                        color: has
+                            ? scheme.onSurface
+                            : scheme.onSurface.withValues(alpha: 0.35),
+                      ),
+                    );
+                  }),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _mutedNote(BuildContext context, String text) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Center(
+        child: Text(
+          text,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bottomPad = MediaQuery.paddingOf(context).bottom;
+
+    if (widget.roster.isEmpty) {
+      return SingleChildScrollView(
+        padding: EdgeInsets.only(bottom: bottomPad),
+        child: _mutedNote(context, 'No roster data'),
+      );
+    }
+
+    final visible = _visibleColumns;
+    final rows = _sortedRows;
+    // Total stat-pane width — the header divider can't size itself inside
+    // the unbounded horizontal scroll view.
+    final statWidth =
+        visible.fold<double>(0, (sum, c) => sum + _columnWidth(c));
+
+    // Zero recorded stats: roster rows with a muted note — never a blank tab.
+    if (visible.isEmpty) {
+      return SingleChildScrollView(
+        padding: EdgeInsets.only(bottom: bottomPad),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _mutedNote(context, 'No stats recorded yet'),
+            const Divider(height: 1, thickness: 1),
+            // Rows read Theme.of(context) — Builder keeps the context live
+            // across theme toggles (itemBuilder staleness rule).
+            for (final p in rows)
+              Builder(builder: (context) => _identityRow(context, p)),
+          ],
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      padding: EdgeInsets.only(bottom: bottomPad),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Frozen identity pane.
+          SizedBox(
+            width: _identityWidth,
+            child: Column(
+              children: [
+                _nameHeader(context),
+                const Divider(height: 1, thickness: 1),
+                for (final p in rows)
+                  Builder(builder: (context) => _identityRow(context, p)),
+              ],
+            ),
+          ),
+          // Swipeable stat pane — shares the outer vertical scroll, so its
+          // rows always align with the frozen pane's.
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Column(
+                children: [
+                  Row(children: [for (final c in visible) _statHeader(context, c)]),
+                  SizedBox(
+                      width: statWidth,
+                      child: const Divider(height: 1, thickness: 1)),
+                  for (final p in rows)
+                    Builder(builder: (context) => _statRow(context, p, visible)),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/match_tabs/team_box_score_tab.dart
+++ b/lib/match_tabs/team_box_score_tab.dart
@@ -39,7 +39,10 @@ class TeamBoxScoreTab extends StatefulWidget {
 }
 
 class _TeamBoxScoreTabState extends State<TeamBoxScoreTab> {
-  static const double _rowHeight = 44;
+  // Tall enough for a two-line name (owner rule: long player names wrap,
+  // never ellipsize — all leagues + tournaments). Shared by the identity
+  // and stat panes so their rows stay aligned.
+  static const double _rowHeight = 52;
   static const double _headerHeight = 36;
   static const double _identityWidth = 168;
 
@@ -226,6 +229,9 @@ class _TeamBoxScoreTabState extends State<TeamBoxScoreTab> {
                   p.name,
                   style:
                       const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+                  // Wrap long names to a second line (owner rule); ellipsis
+                  // only guards truly pathological 3-line names.
+                  maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                 ),
               ),

--- a/lib/misc/league_stat_categories.dart
+++ b/lib/misc/league_stat_categories.dart
@@ -1,0 +1,68 @@
+// ONE source of truth for "which stat categories does a league screen show
+// for this sport", shared by the season Player Stats tab and the team page's
+// Stats tab.
+//
+// Why it lives here: the team page used to carry its own hardcoded futsal
+// list, so a basketball team's Stats tab looked for goals/saves that don't
+// exist and rendered "No stats recorded yet" while the players had 100+
+// points (owner report, PR #11). Any future sport is added ONCE here and
+// every league stat surface picks it up.
+//
+// Keys are the `statByName` keys on TournamentPlayer (extraStats for the
+// per-sport ones); 'icon' is a statIconAsset key ('' = resolve by sport
+// badge or no icon); optional 'suffix' renders after the value.
+
+const Map<String, List<Map<String, String>>> _bySport = {
+  'Futsal': [
+    // Season leaderboards frame this as the scoring race; a team page is
+    // just listing that team's scorers (teamLabel).
+    {'label': 'Top Scorer', 'teamLabel': 'Goals', 'stat': 'goals', 'icon': 'goal'},
+    {'label': 'Assists', 'stat': 'assists', 'icon': 'assist'},
+    {'label': 'Saves', 'stat': 'saves', 'icon': 'save'},
+    {'label': 'Defensive Plays (DPL)', 'stat': 'dpl', 'icon': 'dpl'},
+    {'label': 'Clean Sheets', 'stat': 'cleanSheets', 'icon': ''},
+    {'label': 'Yellow Cards', 'stat': 'yellowCards', 'icon': 'yellow'},
+    {'label': 'Red Cards', 'stat': 'redCards', 'icon': 'red'},
+  ],
+  // Badge sports (isBadgeLeagueSport): the gold bball_*.png / ff_*.png badge
+  // resolves from the stat key via leagueStatIcon(), so 'icon' stays blank.
+  'Basketball': [
+    {'label': 'Points', 'stat': 'points', 'icon': ''},
+    {'label': '3-Pointers', 'stat': 'threePointers', 'icon': ''},
+    {'label': '2-Pointers', 'stat': 'twoPointers', 'icon': ''},
+    {'label': 'Free Throws Made', 'stat': 'freeThrows', 'icon': ''},
+    {'label': 'Rebounds', 'stat': 'rebounds', 'icon': ''},
+    {'label': 'Assists', 'stat': 'assists', 'icon': ''},
+    {'label': 'Steals', 'stat': 'steals', 'icon': ''},
+    {'label': 'Blocks', 'stat': 'blocks', 'icon': ''},
+    {'label': 'Turnovers', 'stat': 'turnovers', 'icon': ''},
+    {'label': 'Fouls', 'stat': 'fouls', 'icon': ''},
+  ],
+  'Flag Football': [
+    {'label': 'Touchdowns', 'stat': 'touchdowns', 'icon': ''},
+    {'label': 'Receptions', 'stat': 'receptions', 'icon': ''},
+    // Derived REC/(REC+RECMiss), gated to >=3 targets in the adapter so tiny
+    // samples never reach the board.
+    {'label': 'Catch %', 'stat': 'catchPercentage', 'icon': '', 'suffix': '%'},
+    {'label': 'Pass TDs', 'stat': 'passTouchdowns', 'icon': ''},
+    {'label': 'Interceptions', 'stat': 'interceptions', 'icon': ''},
+    {'label': 'Flag Pulls', 'stat': 'flagPulls', 'icon': ''},
+    {'label': 'Sacks', 'stat': 'sacks', 'icon': ''},
+  ],
+};
+
+/// Stat categories for [sport]; unknown sports fall back to the futsal set
+/// (soccer shares it), matching the adapter's own default branch.
+///
+/// [forTeamPage] swaps in a category's `teamLabel` where one exists — a
+/// team's own page says "Goals" where the season leaderboard says
+/// "Top Scorer". Same stats, same order, same icons either way.
+List<Map<String, String>> leagueStatCategories(String sport,
+    {bool forTeamPage = false}) {
+  final cats = _bySport[sport] ?? _bySport['Futsal']!;
+  if (!forTeamPage) return cats;
+  return [
+    for (final c in cats)
+      if (c['teamLabel'] == null) c else {...c, 'label': c['teamLabel']!},
+  ];
+}

--- a/lib/misc/single_match_tallies.dart
+++ b/lib/misc/single_match_tallies.dart
@@ -75,15 +75,39 @@ void _applyEvent(Map<String, MatchPlayerTally> out, String type, String player) 
     case 'dpl':
       t.dpl++;
       break;
-    // Basketball (P4)
+    // Cards + fouls (Box Score): both the league spellings (Yellow/Red/
+    // SecondYellow/Foul) and the tournament ones (yellow card/...) land
+    // here. SecondYellow counts as a red, never a first yellow — the
+    // stats-engine convention (statKeys ['SecondYellow', 'Red']).
+    case 'foul':
+      t.counts['fouls'] = (t.counts['fouls'] ?? 0) + 1;
+      break;
+    case 'yellow':
+    case 'yellow card':
+      t.counts['yellowCards'] = (t.counts['yellowCards'] ?? 0) + 1;
+      break;
+    case 'red':
+    case 'red card':
+    case 'secondyellow':
+    case 'second yellow':
+      t.counts['redCards'] = (t.counts['redCards'] ?? 0) + 1;
+      break;
+    // Basketball (P4). Made-shot buckets (Box Score) ride alongside the
+    // weighted 'points' Match Leaders keep reading.
     case 'onepointer':
       t.counts['points'] = (t.counts['points'] ?? 0) + 1;
+      t.counts['freeThrows'] = (t.counts['freeThrows'] ?? 0) + 1;
       break;
     case 'twopointer':
       t.counts['points'] = (t.counts['points'] ?? 0) + 2;
+      t.counts['twoPointers'] = (t.counts['twoPointers'] ?? 0) + 1;
       break;
     case 'threepointer':
       t.counts['points'] = (t.counts['points'] ?? 0) + 3;
+      t.counts['threePointers'] = (t.counts['threePointers'] ?? 0) + 1;
+      break;
+    case 'turnover':
+      t.counts['turnovers'] = (t.counts['turnovers'] ?? 0) + 1;
       break;
     case 'rebound':
       t.counts['rebounds'] = (t.counts['rebounds'] ?? 0) + 1;

--- a/lib/tournament_match_detail.dart
+++ b/lib/tournament_match_detail.dart
@@ -341,14 +341,13 @@ class _TournamentMatchDetailPageState extends State<TournamentMatchDetailPage> {
                   background: _buildScoreboardHeader(context),
                 ),
                 bottom: TabBar(
-                  // Scrollable: team names can be long (spec — team tabs
-                  // rely on the scrollable TabBar).
-                  isScrollable: true,
-                  tabAlignment: TabAlignment.center,
+                  // Owner feedback: the three tabs spread evenly across the
+                  // full width (scrollable clustered them in the center);
+                  // long team names scale down to fit their third.
                   tabs: [
                     const Tab(text: 'Summary'),
-                    Tab(text: team1?.name ?? _match.team1Id ?? 'Team 1'),
-                    Tab(text: team2?.name ?? _match.team2Id ?? 'Team 2'),
+                    teamNameTab(team1?.name ?? _match.team1Id ?? 'Team 1'),
+                    teamNameTab(team2?.name ?? _match.team2Id ?? 'Team 2'),
                   ],
                   labelColor: TournamentColors.headerForeground(context),
                   unselectedLabelColor:

--- a/lib/tournament_match_detail.dart
+++ b/lib/tournament_match_detail.dart
@@ -2,9 +2,11 @@ import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:infinite_sports_flutter/match_tabs/box_score_columns.dart';
+import 'package:infinite_sports_flutter/match_tabs/team_box_score_tab.dart';
 import 'package:infinite_sports_flutter/misc/share_match_card_service.dart';
 import 'package:infinite_sports_flutter/misc/single_match_tallies.dart'
-    show leagueMatchLeaderCategories;
+    show MatchPlayerTally, leagueMatchLeaderCategories, singleMatchPlayerTallies;
 import 'package:infinite_sports_flutter/misc/tournament_colors.dart';
 import 'package:infinite_sports_flutter/misc/tournament_service.dart';
 import 'package:infinite_sports_flutter/model/prediction_config.dart';
@@ -12,7 +14,6 @@ import 'package:infinite_sports_flutter/model/tournamentmatch.dart';
 import 'package:infinite_sports_flutter/model/tournamentplayer.dart';
 import 'package:infinite_sports_flutter/model/tournamentteam.dart';
 import 'package:infinite_sports_flutter/tournament_tabs/match_facts_tab.dart';
-import 'package:infinite_sports_flutter/tournament_tabs/match_lineup_tab.dart';
 import 'package:infinite_sports_flutter/tournament_tabs/stat_icon.dart'
     show isBadgeLeagueSport;
 import 'package:infinite_sports_flutter/tournamentteamdetail.dart';
@@ -50,13 +51,23 @@ class _TournamentMatchDetailPageState extends State<TournamentMatchDetailPage> {
   PredictionConfig? _predictionConfig;
   String _tournamentName = '';
 
+  // Box-score tallies memoized off the live match (tournamentdetail.dart
+  // lag-fix rule): recomputed only when a stream event lands, never in build.
+  late Map<String, MatchPlayerTally> _matchTallies =
+      singleMatchPlayerTallies(_match);
+
   @override
   void initState() {
     super.initState();
     _sub = TournamentService
         .watchMatch(widget.tournamentId, widget.match.id)
         .listen((m) {
-      if (mounted && m != null) setState(() => _match = m);
+      if (mounted && m != null) {
+        setState(() {
+          _match = m;
+          _matchTallies = singleMatchPlayerTallies(m);
+        });
+      }
     });
     TournamentService.getPredictionConfig(widget.tournamentId).then((cfg) {
       if (mounted) setState(() => _predictionConfig = cfg);
@@ -273,9 +284,12 @@ class _TournamentMatchDetailPageState extends State<TournamentMatchDetailPage> {
     final team2 = _match.team2Id != null ? widget.teams[_match.team2Id] : null;
     final team1Players = _match.team1Id != null ? (widget.rosters[_match.team1Id] ?? []) : <TournamentPlayer>[];
     final team2Players = _match.team2Id != null ? (widget.rosters[_match.team2Id] ?? []) : <TournamentPlayer>[];
+    // Per-team box score tabs (Match Box Score spec): the Lineup tab is
+    // hidden — match_lineup_tab.dart survives for the future on-field view.
+    final boxScoreColumns = boxScoreColumnsFor(widget.sport);
 
     return DefaultTabController(
-      length: 2,
+      length: 3,
       child: Scaffold(
         body: NestedScrollView(
           headerSliverBuilder: (context, innerBoxIsScrolled) {
@@ -327,9 +341,14 @@ class _TournamentMatchDetailPageState extends State<TournamentMatchDetailPage> {
                   background: _buildScoreboardHeader(context),
                 ),
                 bottom: TabBar(
-                  tabs: const [
-                    Tab(text: 'Summary'),
-                    Tab(text: 'Lineup')
+                  // Scrollable: team names can be long (spec — team tabs
+                  // rely on the scrollable TabBar).
+                  isScrollable: true,
+                  tabAlignment: TabAlignment.center,
+                  tabs: [
+                    const Tab(text: 'Summary'),
+                    Tab(text: team1?.name ?? _match.team1Id ?? 'Team 1'),
+                    Tab(text: team2?.name ?? _match.team2Id ?? 'Team 2'),
                   ],
                   labelColor: TournamentColors.headerForeground(context),
                   unselectedLabelColor:
@@ -364,14 +383,16 @@ class _TournamentMatchDetailPageState extends State<TournamentMatchDetailPage> {
                 leagueSportKey:
                     isBadgeLeagueSport(widget.sport) ? widget.sport : null,
               ),
-              MatchLineupTab(
-                match: _match,
-                team1: team1,
-                team2: team2,
-                team1Players: team1Players,
-                team2Players: team2Players,
-                sport: widget.sport,
-              )
+              TeamBoxScoreTab(
+                roster: team1Players,
+                tallies: _matchTallies,
+                columns: boxScoreColumns,
+              ),
+              TeamBoxScoreTab(
+                roster: team2Players,
+                tallies: _matchTallies,
+                columns: boxScoreColumns,
+              ),
             ],
           ),
         ),

--- a/lib/tournamentdetail.dart
+++ b/lib/tournamentdetail.dart
@@ -36,7 +36,10 @@ class TournamentDetailPage extends StatefulWidget {
 }
 
 class _TournamentDetailPageState extends State<TournamentDetailPage>
-    with SingleTickerProviderStateMixin {
+    // TickerProviderStateMixin (not Single-): the bleed fix recreates the
+    // TabController when the tournament identity changes, so this State can
+    // legitimately own more than one ticker over its lifetime.
+    with TickerProviderStateMixin {
   bool _isLoading = true;
   String? _loadError;
   Tournament? _tournament;
@@ -70,6 +73,38 @@ class _TournamentDetailPageState extends State<TournamentDetailPage>
     _loadData();
   }
 
+  /// Cross-tournament bleed fix (owner bug report 2026-07-30): this State
+  /// only loaded in initState, so if Flutter reuses the element with a
+  /// DIFFERENT tournamentId (position-based reuse in tab/list structures —
+  /// reproduced in integration_test/tournament_bleed_test.dart) the page
+  /// kept rendering the previous tournament's teams/matches/stats. On an
+  /// identity change: drop every stream and every piece of loaded state,
+  /// show the skeleton, and reload as if freshly pushed.
+  @override
+  void didUpdateWidget(covariant TournamentDetailPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.tournamentId == widget.tournamentId) return;
+    _matchesSub?.cancel();
+    _matchesSub = null;
+    _tournamentSub?.cancel();
+    _tournamentSub = null;
+    _tabController?.dispose();
+    _tabController = null;
+    setState(() {
+      _isLoading = true;
+      _loadError = null;
+      _tournament = null;
+      _teams = {};
+      _matches = [];
+      _rosters = {};
+      _stats = null;
+      _predictionConfig = null;
+      _tabs = const [];
+      _predictIndex = -1;
+    });
+    _loadData();
+  }
+
   @override
   void dispose() {
     _matchesSub?.cancel();
@@ -79,16 +114,22 @@ class _TournamentDetailPageState extends State<TournamentDetailPage>
   }
 
   Future<void> _loadData() async {
+    // Identity guard (bleed fix): if didUpdateWidget swaps the tournament
+    // while this load is in flight, every continuation below must drop its
+    // results instead of writing tournament A's data into B's page (or
+    // re-binding A's live streams over B's).
+    final loadId = widget.tournamentId;
+    bool stale() => !mounted || loadId != widget.tournamentId;
     try {
       // One parallel wave (was three sequential ones: header/teams/matches →
       // rosters+avatars → config). The raw rosters node rides along and is
       // parsed once teams land; avatar fetches never gate first paint.
       final results = await Future.wait([
-        TournamentService.getTournamentHeader(widget.tournamentId),
-        TournamentService.getTeams(widget.tournamentId),
-        TournamentService.getMatches(widget.tournamentId),
-        TournamentService.getPredictionConfig(widget.tournamentId),
-        TournamentService.getRostersNode(widget.tournamentId),
+        TournamentService.getTournamentHeader(loadId),
+        TournamentService.getTeams(loadId),
+        TournamentService.getMatches(loadId),
+        TournamentService.getPredictionConfig(loadId),
+        TournamentService.getRostersNode(loadId),
       ]);
 
       final tournament = results[0] as Tournament?;
@@ -100,7 +141,7 @@ class _TournamentDetailPageState extends State<TournamentDetailPage>
       final tabs = <Tab>[..._baseTabs];
       if (config.open) tabs.add(const Tab(text: 'Predict'));
 
-      if (!mounted) return;
+      if (stale()) return;
       setState(() {
         _tournament = tournament;
         _teams = teams;
@@ -122,7 +163,7 @@ class _TournamentDetailPageState extends State<TournamentDetailPage>
       // Avatars for linked players not yet in the session cache land in a
       // single follow-up update behind the first paint.
       TournamentService.enrichRosterPhotos(rosters).then((enriched) {
-        if (!mounted) return;
+        if (stale()) return;
         setState(() {
           _rosters = enriched;
           _stats = computeTournamentStats(
@@ -135,10 +176,10 @@ class _TournamentDetailPageState extends State<TournamentDetailPage>
 
       // Keep matches live after the initial paint: scores, clock, standings and
       // the bracket all update in place without a manual refresh.
+      if (stale()) return;
       _matchesSub?.cancel();
-      _matchesSub =
-          TournamentService.watchMatches(widget.tournamentId).listen((live) {
-        if (!mounted || live.isEmpty) return;
+      _matchesSub = TournamentService.watchMatches(loadId).listen((live) {
+        if (stale() || live.isEmpty) return;
         setState(() {
           _matches = live;
           _stats = computeTournamentStats(
@@ -155,14 +196,13 @@ class _TournamentDetailPageState extends State<TournamentDetailPage>
       // null emission means the record is momentarily unparseable, so the
       // last good header is kept rather than blanked.
       _tournamentSub?.cancel();
-      _tournamentSub =
-          TournamentService.watchTournament(widget.tournamentId).listen((live) {
-        if (!mounted || live == null) return;
+      _tournamentSub = TournamentService.watchTournament(loadId).listen((live) {
+        if (stale() || live == null) return;
         setState(() => _tournament = live);
       });
     } catch (e, st) {
       debugPrint('TournamentDetailPage._loadData error: $e\n$st');
-      if (!mounted) return;
+      if (stale()) return;
       setState(() {
         _isLoading = false;
         _loadError = 'Could not load tournament. Tap retry.';

--- a/lib/tournamentteamdetail.dart
+++ b/lib/tournamentteamdetail.dart
@@ -55,8 +55,13 @@ class _TournamentTeamDetailPageState extends State<TournamentTeamDetailPage>
   // per history row!) on every frame. Invalidated (_stats = null) only when
   // matches/rosters change; computed at most once per data change.
   ComputedTournamentStats? _stats;
+  // `sport` is REQUIRED here (PR #11 review): the engine zero-inits a
+  // sport-specific counter set, so omitting it defaulted every tournament
+  // to Soccer keys — a basketball team's Stats tab found no points/rebounds
+  // and rendered completely blank.
   ComputedTournamentStats get _computedStats => _stats ??=
-      computeTournamentStats(matches: _matches, rosters: _rosters);
+      computeTournamentStats(
+          matches: _matches, rosters: _rosters, sport: widget.sport);
   late TabController _tabController;
   late Future<List<Map<String, dynamic>>> _historyFuture;
   final Set<String> _expandedStats = {};
@@ -687,6 +692,25 @@ class _TournamentTeamDetailPageState extends State<TournamentTeamDetailPage>
       final filtered = players.where((p) => getValue(p, stat) > 0).toList()
         ..sort((a, b) => getValue(b, stat).compareTo(getValue(a, stat)));
       return filtered;
+    }
+
+    // Every category empty (nothing recorded yet for this sport) — say so
+    // instead of rendering a blank tab (PR #11 review).
+    final hasAnyStat =
+        categories.any((c) => getAllSorted(c['stat']!).isNotEmpty);
+    if (!hasAnyStat) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(
+            'No stats recorded yet',
+            style: TextStyle(
+              color:
+                  Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
+            ),
+          ),
+        ),
+      );
     }
 
     return ListView.builder(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,6 +415,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.1"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_form_builder:
     dependency: "direct main"
     description:
@@ -542,6 +547,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   geoclue:
     dependency: transitive
     description:
@@ -846,6 +856,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.2"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   intl:
     dependency: "direct main"
     description:
@@ -1110,6 +1125,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   provider:
     dependency: "direct main"
     description:
@@ -1355,6 +1378,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "12.6.0"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
@@ -1507,6 +1538,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webview_flutter:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/box_score_columns_test.dart
+++ b/test/box_score_columns_test.dart
@@ -1,0 +1,186 @@
+// Unit tests for the pure box-score column layer (Match Box Score spec,
+// 2026-07-28): per-sport column sets, the auto-hide filter, derived PTS /
+// Catch %, and the sort helper. Firebase-free by construction.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_sports_flutter/match_tabs/box_score_columns.dart';
+import 'package:infinite_sports_flutter/misc/single_match_tallies.dart';
+import 'package:infinite_sports_flutter/model/tournamentplayer.dart';
+
+MatchPlayerTally _t({
+  int goals = 0,
+  int assists = 0,
+  int saves = 0,
+  int dpl = 0,
+  Map<String, int> counts = const {},
+}) {
+  final t = MatchPlayerTally()
+    ..goals = goals
+    ..assists = assists
+    ..saves = saves
+    ..dpl = dpl;
+  t.counts.addAll(counts);
+  return t;
+}
+
+TournamentPlayer _p(String name) => TournamentPlayer(
+      name: name,
+      teamId: 'T',
+      teamName: 'T',
+      goals: 0,
+      assists: 0,
+      saves: 0,
+      dpl: 0,
+      cleanSheets: 0,
+      yellowCards: 0,
+      redCards: 0,
+    );
+
+List<String> _keys(String sport) =>
+    boxScoreColumnsFor(sport).map((c) => c.key).toList();
+
+BoxScoreColumn _col(String sport, String key) =>
+    boxScoreColumnsFor(sport).firstWhere((c) => c.key == key);
+
+void main() {
+  group('per-sport column sets (spec table, importance order)', () {
+    test('soccer/futsal: Goals first; Fouls defined (capture records Foul)',
+        () {
+      const expected = [
+        'goals', 'assists', 'dpl', 'saves', 'fouls', 'yellowCards', 'redCards',
+      ];
+      expect(_keys('Futsal'), expected);
+      // Soccer shares futsal's set — and the same instance, so widget-level
+      // identity caching holds.
+      expect(identical(boxScoreColumnsFor('Soccer'), boxScoreColumnsFor('Futsal')),
+          isTrue);
+    });
+
+    test('basketball: PTS first; Fouls defined (capture records Foul)', () {
+      expect(_keys('Basketball'), [
+        'points', 'rebounds', 'assists', 'threePointers', 'twoPointers',
+        'freeThrows', 'steals', 'blocks', 'turnovers', 'fouls',
+      ]);
+    });
+
+    test('flag football: NO fouls column — its capture records no foul events',
+        () {
+      expect(_keys('Flag Football'), [
+        'touchdowns', 'passTouchdowns', 'receptions', 'interceptions',
+        'flagPulls', 'sacks', 'catchPercentage',
+      ]);
+      expect(_keys('Flag Football'), isNot(contains('fouls')));
+    });
+
+    test('unknown sport falls back to the soccer/futsal set', () {
+      expect(identical(boxScoreColumnsFor('Volleyball'),
+          boxScoreColumnsFor('Futsal')), isTrue);
+    });
+  });
+
+  group('derived values', () {
+    test('PTS = FT + 2x2PT + 3x3PT from the made-shot buckets', () {
+      final pts = _col('Basketball', 'points');
+      expect(
+          pts.valueOf(_t(counts: {
+            'freeThrows': 2,
+            'twoPointers': 3,
+            'threePointers': 1,
+          })),
+          11);
+      expect(pts.valueOf(null), 0);
+    });
+
+    test('Catch % is ungated: real rate with any targets, null without', () {
+      final pct = _col('Flag Football', 'catchPercentage');
+      expect(pct.valueOf(_t(counts: {'receptions': 3, 'recMisses': 1})), 75);
+      // 1/1 shows 100% here (Match Leaders gates this to >=3 targets; the
+      // box score shows the player's real rate).
+      expect(pct.valueOf(_t(counts: {'receptions': 1})), 100);
+      expect(pct.valueOf(_t()), isNull); // no targets = no data, not 0%
+      expect(pct.valueOf(null), isNull);
+      expect(pct.suffix, '%');
+    });
+  });
+
+  group('visibleColumns (auto-hide)', () {
+    test('keeps only columns some player recorded', () {
+      final visible = visibleColumns(
+        boxScoreColumnsFor('Futsal'),
+        [_t(goals: 2), _t(assists: 1), _t()],
+      );
+      expect(visible.map((c) => c.key), ['goals', 'assists']);
+    });
+
+    test('empty match (no tallies) hides every column', () {
+      expect(visibleColumns(boxScoreColumnsFor('Futsal'), const []), isEmpty);
+      expect(visibleColumns(boxScoreColumnsFor('Basketball'), [_t(), _t()]),
+          isEmpty);
+    });
+
+    test('Catch % stays hidden when no one has targets', () {
+      final visible = visibleColumns(
+        boxScoreColumnsFor('Flag Football'),
+        [_t(counts: {'touchdowns': 1})],
+      );
+      expect(visible.map((c) => c.key), ['touchdowns']);
+    });
+  });
+
+  group('sortedBoxScoreRows', () {
+    final roster = [_p('Ashur'), _p('Ninos'), _p('Sargon')];
+    final tallies = {
+      'Ashur': _t(goals: 1),
+      'Ninos': _t(goals: 3),
+      // Sargon: no events this match (null tally).
+    };
+    final goals = _col('Futsal', 'goals');
+
+    test('descending = best first; no-event players sink last', () {
+      final rows = sortedBoxScoreRows(roster, tallies,
+          column: goals, ascending: false);
+      expect(rows.map((p) => p.name), ['Ninos', 'Ashur', 'Sargon']);
+    });
+
+    test('ascending toggles the order', () {
+      final rows =
+          sortedBoxScoreRows(roster, tallies, column: goals, ascending: true);
+      expect(rows.map((p) => p.name), ['Sargon', 'Ashur', 'Ninos']);
+    });
+
+    test('name sort: A-Z and Z-A', () {
+      expect(
+        sortedBoxScoreRows(roster, tallies, column: null, ascending: true)
+            .map((p) => p.name),
+        ['Ashur', 'Ninos', 'Sargon'],
+      );
+      expect(
+        sortedBoxScoreRows(roster, tallies, column: null, ascending: false)
+            .map((p) => p.name),
+        ['Sargon', 'Ninos', 'Ashur'],
+      );
+    });
+
+    test('stat ties always break A-Z, either direction', () {
+      final tied = {'Ninos': _t(goals: 2), 'Ashur': _t(goals: 2)};
+      for (final asc in [true, false]) {
+        final rows = sortedBoxScoreRows([_p('Ninos'), _p('Ashur')], tied,
+            column: goals, ascending: asc);
+        expect(rows.map((p) => p.name), ['Ashur', 'Ninos']);
+      }
+    });
+
+    test('null Catch % ("no data") sorts below a real 0-adjacent value', () {
+      final pct = _col('Flag Football', 'catchPercentage');
+      final rows = sortedBoxScoreRows(
+        [_p('NoTargets'), _p('Receiver')],
+        {
+          'Receiver': _t(counts: {'receptions': 0, 'recMisses': 2}), // 0%
+        },
+        column: pct,
+        ascending: false,
+      );
+      expect(rows.map((p) => p.name), ['Receiver', 'NoTargets']);
+    });
+  });
+}

--- a/test/league_match_detail_tabs_test.dart
+++ b/test/league_match_detail_tabs_test.dart
@@ -1,24 +1,27 @@
-// Widget test for the league match page's Facts/Lineup tab structure
-// (L6.2 Task 1: parity with TournamentMatchDetailPage).
+// Widget test for the league match page's tab structure (Match Box Score
+// spec, 2026-07-28: Summary | <Team 1> | <Team 2> — the Lineup tab is
+// hidden until the on-field lineup epic revives it).
 //
 // LeagueMatchDetailPage itself can't be pumped directly in a widget test:
 // its State subscribes to LeagueService Firebase streams with no injection
 // seam (the same constraint documented in league_team_detail_tabs_test.dart
 // and league_tab_swap_test.dart for the sibling league pages). So this
-// harness reproduces the exact DefaultTabController + TabBar([Facts,
-// Lineup]) + TabBarView([MatchFactsTab, MatchLineupTab]) the page's build
-// method wires, fed by the same Firebase-free adapters
-// (leagueMatchFromGameMap / leagueTeamStub / leagueRostersFromLineupsNode)
-// LeagueMatchDetailPage itself uses.
+// harness reproduces the exact DefaultTabController + TabBar([Summary,
+// team1, team2]) + TabBarView([MatchFactsTab, TeamBoxScoreTab x2]) the
+// page's build method wires, fed by the same Firebase-free adapters
+// (leagueMatchFromGameMap / leagueTeamStub / leagueRostersFromLineupsNode /
+// singleMatchPlayerTallies) LeagueMatchDetailPage itself uses.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_sports_flutter/match_tabs/box_score_columns.dart';
+import 'package:infinite_sports_flutter/match_tabs/team_box_score_tab.dart';
 import 'package:infinite_sports_flutter/misc/league_adapters.dart';
+import 'package:infinite_sports_flutter/misc/single_match_tallies.dart';
 import 'package:infinite_sports_flutter/model/tournamentmatch.dart';
 import 'package:infinite_sports_flutter/model/tournamentplayer.dart';
 import 'package:infinite_sports_flutter/model/tournamentteam.dart';
 import 'package:infinite_sports_flutter/tournament_tabs/match_facts_tab.dart';
-import 'package:infinite_sports_flutter/tournament_tabs/match_lineup_tab.dart';
 
 Widget _harness({
   required TournamentMatch match,
@@ -28,17 +31,25 @@ Widget _harness({
   required List<TournamentPlayer> team2Players,
   required String sport,
 }) {
+  final tallies = singleMatchPlayerTallies(match);
+  final columns = boxScoreColumnsFor(sport);
   return MaterialApp(
     home: DefaultTabController(
-      length: 2,
+      length: 3,
       child: Scaffold(
         body: NestedScrollView(
           headerSliverBuilder: (context, innerBoxIsScrolled) => [
             SliverAppBar(
               pinned: true,
               expandedHeight: 196,
-              bottom: const TabBar(
-                tabs: [Tab(text: 'Facts'), Tab(text: 'Lineup')],
+              bottom: TabBar(
+                isScrollable: true,
+                tabAlignment: TabAlignment.center,
+                tabs: [
+                  const Tab(text: 'Summary'),
+                  Tab(text: team1?.name ?? match.team1Id ?? 'Team 1'),
+                  Tab(text: team2?.name ?? match.team2Id ?? 'Team 2'),
+                ],
               ),
             ),
           ],
@@ -52,13 +63,15 @@ Widget _harness({
                 team2Players: team2Players,
                 leagueSportKey: sport,
               ),
-              MatchLineupTab(
-                match: match,
-                team1: team1,
-                team2: team2,
-                team1Players: team1Players,
-                team2Players: team2Players,
-                sport: sport,
+              TeamBoxScoreTab(
+                roster: team1Players,
+                tallies: tallies,
+                columns: columns,
+              ),
+              TeamBoxScoreTab(
+                roster: team2Players,
+                tallies: tallies,
+                columns: columns,
               ),
             ],
           ),
@@ -69,8 +82,10 @@ Widget _harness({
 }
 
 void main() {
-  testWidgets('league match page shows both Facts and Lineup tabs; Lineup '
-      'renders the same rosters the Facts tab uses', (tester) async {
+  testWidgets(
+      'league match page shows Summary + one tab per team; a team tab '
+      'renders that team\'s box score from the same rosters/activity the '
+      'Summary tab uses', (tester) async {
     final match = leagueMatchFromGameMap(
       dateKey: '06152026',
       index: 0,
@@ -80,6 +95,11 @@ void main() {
         'team1score': 2,
         'team2score': 1,
         'status': 2,
+        'team1activity': {
+          "7'": [
+            {'Goal': 'Ashur'},
+          ],
+        },
       },
     );
     final rosters = leagueRostersFromLineupsNode('Futsal', {
@@ -100,17 +120,29 @@ void main() {
       sport: 'Futsal',
     ));
 
-    // Both tab labels present; Facts is the initial view (no roster names
-    // rendered directly there — just the timeline/leaders/location).
-    expect(find.text('Facts'), findsOneWidget);
-    expect(find.text('Lineup'), findsOneWidget);
-    expect(find.text('Ashur'), findsNothing);
+    // All three tab labels present; Summary is the initial view (no roster
+    // rows rendered there — just the timeline/leaders/location). 'Ashur'
+    // appears once in the Summary timeline for his goal.
+    expect(find.text('Summary'), findsOneWidget);
+    expect(find.text('Nineveh'), findsOneWidget);
+    expect(find.text('Babylon'), findsOneWidget);
+    expect(find.text('#10'), findsNothing);
 
-    await tester.tap(find.text('Lineup'));
+    await tester.tap(find.text('Nineveh'));
     await tester.pumpAndSettle();
 
-    // Lineup tab renders both team rosters (same players fed to Facts).
+    // Team tab renders the team's box score rows (name + number) with the
+    // Goals column visible (recorded) and all-zero columns hidden.
     expect(find.text('Ashur'), findsOneWidget);
+    expect(find.text('#10'), findsOneWidget);
+    expect(find.text('Goals'), findsOneWidget);
+    expect(find.text('Saves'), findsNothing);
+
+    // Other team's tab shows its own roster only.
+    await tester.tap(find.text('Babylon'));
+    await tester.pumpAndSettle();
     expect(find.text('Ninos'), findsOneWidget);
+    expect(find.text('#9'), findsOneWidget);
+    expect(find.text('Ashur'), findsNothing);
   });
 }

--- a/test/league_stat_categories_test.dart
+++ b/test/league_stat_categories_test.dart
@@ -1,0 +1,53 @@
+// Guard for the "stat screen hardcoded to futsal" bug class (owner report,
+// PR #11): a basketball league team's Stats tab rendered "No stats recorded
+// yet" while its players had 100+ points, because the tab carried its own
+// futsal-only category list. Every league stat surface now reads these
+// per-sport categories from one place.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_sports_flutter/misc/league_adapters.dart';
+import 'package:infinite_sports_flutter/misc/league_stat_categories.dart';
+
+void main() {
+  String labelsOf(String sport) =>
+      leagueStatCategories(sport).map((c) => c['label']).join(', ');
+
+  test('each sport gets its own categories', () {
+    expect(labelsOf('Basketball'), contains('Rebounds'));
+    expect(labelsOf('Basketball'), isNot(contains('Clean Sheets')));
+    expect(labelsOf('Flag Football'), contains('Touchdowns'));
+    expect(labelsOf('Futsal'), contains('Top Scorer'));
+  });
+
+  test('unknown sports fall back to the futsal set', () {
+    expect(leagueStatCategories('Soccer'), leagueStatCategories('Futsal'));
+    expect(leagueStatCategories('Cricket'), leagueStatCategories('Futsal'));
+  });
+
+  test('categories resolve real values on adapted basketball players', () {
+    // Shape mirrors /Basketball/<season>/Line Ups/<team>/<player>.
+    final p = leaguePlayerFromLineup(
+      sport: 'Basketball',
+      name: 'Alderin Babayan',
+      teamName: 'Ishtar',
+      raw: const {
+        'OnePoint': 8, 'TwoPoints': 14, 'ThreePoints': 27,
+        'Rebounds': 41, 'Misses': 62, 'Total': 117, 'number': '11',
+      },
+    );
+    final hits = leagueStatCategories('Basketball')
+        .where((c) => p.statByName(c['stat']!) > 0)
+        .map((c) => c['label'])
+        .toList();
+    expect(hits, contains('Points'));
+    expect(hits, contains('Rebounds'));
+    expect(p.statByName('points'), 117);
+
+    // The old futsal-only list found nothing on the same player — that is
+    // exactly what produced the blank tab.
+    final futsalHits = leagueStatCategories('Futsal')
+        .where((c) => p.statByName(c['stat']!) > 0)
+        .toList();
+    expect(futsalHits, isEmpty);
+  });
+}

--- a/test/league_team_detail_tabs_test.dart
+++ b/test/league_team_detail_tabs_test.dart
@@ -274,6 +274,7 @@ void main() {
         'season-total leader cards: zero counts excluded, leader circled',
         (tester) async {
       await tester.pumpWidget(_wrap(LeagueTeamStatsTab(
+          sport: 'Futsal',
         roster: _roster(),
         rosterLoaded: true,
         onPlayerTap: (_) {},
@@ -307,6 +308,7 @@ void main() {
     testWidgets('stat rows tap through to player profiles', (tester) async {
       TournamentPlayer? tapped;
       await tester.pumpWidget(_wrap(LeagueTeamStatsTab(
+          sport: 'Futsal',
         roster: _roster(),
         rosterLoaded: true,
         onPlayerTap: (p) => tapped = p,
@@ -317,6 +319,7 @@ void main() {
 
     testWidgets('empty roster shows the placeholder', (tester) async {
       await tester.pumpWidget(_wrap(LeagueTeamStatsTab(
+          sport: 'Futsal',
         roster: const [],
         rosterLoaded: true,
         onPlayerTap: (_) {},

--- a/test/single_match_tallies_test.dart
+++ b/test/single_match_tallies_test.dart
@@ -42,7 +42,8 @@ void main() {
     expect(t['Gary']!.dpl, 1);
   });
 
-  test('non-counter events ignored; empty when no activity', () {
+  test('unrelated events never leak into goals/saves; empty when no activity',
+      () {
     final t = singleMatchPlayerTallies(m({
       '1': [
         {'foul': 'Sam'},
@@ -194,6 +195,62 @@ void main() {
           .firstWhere((c) => c['stat'] == 'catchPercentage');
       expect(cat['label'], 'Catch %');
       expect(cat['suffix'], '%');
+    });
+  });
+
+  group('Box Score — cards / fouls / turnovers / made-shot buckets', () {
+    test('league spellings: Foul, Yellow, Red, SecondYellow', () {
+      final t = singleMatchPlayerTallies(matchWithActivities(team1Activity: {
+        "5'": [
+          {'Foul': 'Sam'},
+          {'Yellow': 'Sam'},
+          {'Red': 'Kai'},
+          {'SecondYellow': 'Ann'},
+        ],
+      }));
+      expect(t['Sam']!.counts['fouls'], 1);
+      expect(t['Sam']!.counts['yellowCards'], 1);
+      expect(t['Kai']!.counts['redCards'], 1);
+      // SecondYellow counts as a red, never a first yellow (stats-engine
+      // convention: statKeys ['SecondYellow', 'Red']).
+      expect(t['Ann']!.counts['redCards'], 1);
+      expect(t['Ann']!.counts['yellowCards'], isNull);
+    });
+
+    test('tournament spellings: foul, yellow card, red card, second yellow',
+        () {
+      final t = singleMatchPlayerTallies(matchWithActivities(team1Activity: {
+        '5': [
+          {'foul': 'Sam'},
+          {'yellow card': 'Sam'},
+          {'red card': 'Kai'},
+          {'second yellow': 'Ann'},
+        ],
+      }));
+      expect(t['Sam']!.counts['fouls'], 1);
+      expect(t['Sam']!.counts['yellowCards'], 1);
+      expect(t['Kai']!.counts['redCards'], 1);
+      expect(t['Ann']!.counts['redCards'], 1);
+    });
+
+    test('basketball made-shot buckets ride alongside weighted points; '
+        'Turnover and Foul count', () {
+      final t = singleMatchPlayerTallies(matchWithActivities(team1Activity: {
+        "3'": [
+          {'OnePointer': 'Sam'},
+          {'OnePointer': 'Sam'},
+          {'TwoPointer': 'Sam'},
+          {'ThreePointer': 'Sam'},
+          {'Turnover': 'Sam'},
+          {'Foul': 'Sam'},
+        ],
+      }));
+      expect(t['Sam']!.counts['freeThrows'], 2);
+      expect(t['Sam']!.counts['twoPointers'], 1);
+      expect(t['Sam']!.counts['threePointers'], 1);
+      expect(t['Sam']!.byStat('points'), 7); // 2 + 2 + 3 — Leaders unchanged
+      expect(t['Sam']!.counts['turnovers'], 1);
+      expect(t['Sam']!.counts['fouls'], 1);
     });
   });
 

--- a/test/team_box_score_tab_test.dart
+++ b/test/team_box_score_tab_test.dart
@@ -1,0 +1,164 @@
+// Widget tests for TeamBoxScoreTab (Match Box Score spec, 2026-07-28).
+// Firebase-free: the widget takes plain roster/tally data, and the
+// `openProfileOverride` seam (insiders_leaderboard_page convention)
+// replaces openPlayerProfileById so no ProfilePage is ever constructed.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_sports_flutter/match_tabs/box_score_columns.dart';
+import 'package:infinite_sports_flutter/match_tabs/team_box_score_tab.dart';
+import 'package:infinite_sports_flutter/misc/single_match_tallies.dart';
+import 'package:infinite_sports_flutter/model/tournamentplayer.dart';
+
+TournamentPlayer _p(String name, {String? number, String? uid}) =>
+    TournamentPlayer(
+      name: name,
+      teamId: 'T',
+      teamName: 'T',
+      number: number,
+      uid: uid,
+      goals: 0,
+      assists: 0,
+      saves: 0,
+      dpl: 0,
+      cleanSheets: 0,
+      yellowCards: 0,
+      redCards: 0,
+    );
+
+MatchPlayerTally _goals(int n) => MatchPlayerTally()..goals = n;
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<TournamentPlayer> roster,
+  Map<String, MatchPlayerTally> tallies = const {},
+  List<BoxScoreColumn>? columns,
+  Future<void> Function(BuildContext context,
+          {String? uid, required String name})?
+      openProfileOverride,
+}) async {
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: TeamBoxScoreTab(
+        roster: roster,
+        tallies: tallies,
+        columns: columns ?? boxScoreColumnsFor('Futsal'),
+        openProfileOverride: openProfileOverride,
+      ),
+    ),
+  ));
+}
+
+/// Vertical position of a rendered text — for asserting row order.
+double _dy(WidgetTester tester, String text) =>
+    tester.getTopLeft(find.text(text)).dy;
+
+void main() {
+  testWidgets('renders roster rows with names and jersey numbers',
+      (tester) async {
+    await _pump(tester,
+        roster: [_p('Ashur', number: '10'), _p('Ninos', number: '9')],
+        tallies: {'Ashur': _goals(2)});
+
+    expect(find.text('Ashur'), findsOneWidget);
+    expect(find.text('Ninos'), findsOneWidget);
+    expect(find.text('#10'), findsOneWidget);
+    expect(find.text('#9'), findsOneWidget);
+    expect(find.text('Goals'), findsOneWidget);
+  });
+
+  testWidgets('auto-hides columns nobody recorded', (tester) async {
+    await _pump(tester,
+        roster: [_p('Ashur'), _p('Ninos')],
+        tallies: {'Ashur': _goals(1)});
+
+    expect(find.text('Goals'), findsOneWidget);
+    expect(find.text('Assists'), findsNothing);
+    expect(find.text('Saves'), findsNothing);
+    expect(find.text('Fouls'), findsNothing);
+  });
+
+  testWidgets(
+      'zero recorded stats: roster rows render under a muted note — never a '
+      'blank tab', (tester) async {
+    await _pump(tester, roster: [_p('Ashur', number: '10'), _p('Ninos')]);
+
+    expect(find.text('No stats recorded yet'), findsOneWidget);
+    expect(find.text('Ashur'), findsOneWidget);
+    expect(find.text('Ninos'), findsOneWidget);
+    expect(find.text('#10'), findsOneWidget);
+    expect(find.text('Goals'), findsNothing); // no headers in the empty state
+  });
+
+  testWidgets('default sort is primary stat descending; tapping the header '
+      'toggles to ascending', (tester) async {
+    await _pump(tester,
+        roster: [_p('Ashur'), _p('Ninos')],
+        tallies: {'Ashur': _goals(1), 'Ninos': _goals(3)});
+
+    // Best first: Ninos (3) above Ashur (1).
+    expect(_dy(tester, 'Ninos'), lessThan(_dy(tester, 'Ashur')));
+
+    await tester.tap(find.text('Goals'));
+    await tester.pump();
+
+    expect(_dy(tester, 'Ashur'), lessThan(_dy(tester, 'Ninos')));
+  });
+
+  testWidgets('tapping another stat header switches the sort to it',
+      (tester) async {
+    await _pump(tester, roster: [
+      _p('Ashur'),
+      _p('Ninos')
+    ], tallies: {
+      'Ashur': _goals(2),
+      'Ninos': MatchPlayerTally()
+        ..goals = 1
+        ..assists = 4,
+    });
+
+    expect(_dy(tester, 'Ashur'), lessThan(_dy(tester, 'Ninos'))); // by goals
+
+    await tester.tap(find.text('Assists'));
+    await tester.pump();
+
+    expect(_dy(tester, 'Ninos'), lessThan(_dy(tester, 'Ashur')));
+  });
+
+  testWidgets('name header sorts alphabetically, toggling A-Z / Z-A',
+      (tester) async {
+    await _pump(tester,
+        roster: [_p('Zaya'), _p('Adam')],
+        tallies: {'Zaya': _goals(5), 'Adam': _goals(1)});
+
+    // Default: best first.
+    expect(_dy(tester, 'Zaya'), lessThan(_dy(tester, 'Adam')));
+
+    await tester.tap(find.text('Player'));
+    await tester.pump();
+    expect(_dy(tester, 'Adam'), lessThan(_dy(tester, 'Zaya'))); // A-Z
+
+    await tester.tap(find.text('Player'));
+    await tester.pump();
+    expect(_dy(tester, 'Zaya'), lessThan(_dy(tester, 'Adam'))); // Z-A
+  });
+
+  testWidgets('tapping a player row opens their profile via the seam',
+      (tester) async {
+    String? openedUid;
+    String? openedName;
+    await _pump(tester,
+        roster: [_p('Ashur', uid: 'u1')],
+        tallies: {'Ashur': _goals(1)},
+        openProfileOverride: (context, {uid, required name}) async {
+      openedUid = uid;
+      openedName = name;
+    });
+
+    await tester.tap(find.text('Ashur'));
+    await tester.pump();
+
+    expect(openedUid, 'u1');
+    expect(openedName, 'Ashur');
+  });
+}

--- a/test/tournament_team_stats_sport_test.dart
+++ b/test/tournament_team_stats_sport_test.dart
@@ -1,0 +1,58 @@
+// PR #11 review guard: the team page's Stats tab must aggregate with the
+// tournament's OWN sport. Before the fix tournamentteamdetail.dart called
+// computeTournamentStats without `sport`, so it fell back to Soccer keys —
+// a basketball team's Stats tab found no points/rebounds and rendered
+// completely blank. Fixture style mirrors tournament_stats_engine_test.dart
+// (direct constructor, status 2 = finished).
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:infinite_sports_flutter/misc/tournament_stats_engine.dart';
+import 'package:infinite_sports_flutter/model/tournamentmatch.dart';
+import 'package:infinite_sports_flutter/model/tournamentplayer.dart';
+
+TournamentPlayer _player(String name, String teamId) => TournamentPlayer(
+      name: name, teamId: teamId, teamName: teamId,
+      goals: 0, assists: 0, saves: 0, dpl: 0, cleanSheets: 0,
+      yellowCards: 0, redCards: 0,
+    );
+
+TournamentMatch _basketballMatch() => TournamentMatch(
+      id: 'm1', stage: 'Group Stage', label: 'Group Stage', date: '08272026',
+      team1Id: 'akkad01', team2Id: 'ashur01',
+      team1Score: 5, team2Score: 0, status: 2,
+      team1Activity: {
+        '5': [
+          {'TwoPointer': 'Ann'},
+          {'ThreePointer': 'Ann'},
+          {'Rebound': 'Ann'},
+        ],
+      },
+      bracketPosition: 0,
+    );
+
+void main() {
+  final rosters = {
+    'akkad01': [_player('Ann', 'akkad01')],
+    'ashur01': [_player('Bob', 'ashur01')],
+  };
+
+  test('basketball counters populate when the sport is passed', () {
+    final stats = computeTournamentStats(
+      matches: [_basketballMatch()],
+      rosters: rosters,
+      sport: 'Basketball',
+    );
+    expect(stats.statByName('akkad01', 'Ann', 'twoPointers'), 1);
+    expect(stats.statByName('akkad01', 'Ann', 'threePointers'), 1);
+    expect(stats.statByName('akkad01', 'Ann', 'rebounds'), 1);
+    expect(stats.statByName('akkad01', 'Ann', 'points'), 5);
+  });
+
+  test('omitting the sport yields no basketball counters (the fixed bug)', () {
+    final stats = computeTournamentStats(
+      matches: [_basketballMatch()],
+      rosters: rosters,
+    );
+    expect(stats.statByName('akkad01', 'Ann', 'points'), 0);
+  });
+}


### PR DESCRIPTION
## Summary
- Match pages (league + tournament, all sports) get a FotMob-style box score: tabs are now **Summary | Team 1 | Team 2**, each team tab showing every player's stats for that game
- Frozen identity column (photo, name, jersey #) with horizontally swipeable stat columns, ordered most-important first; tap any header to sort (desc/asc), name header sorts A–Z; default order is best performers first
- Columns auto-hide when no player recorded that stat in the match (both team tabs always show the same set); a match with no stats shows the roster with a friendly note
- Per-sport columns — Soccer/Futsal: Goals, Assists, DPL, Saves, Fouls, Yellow, Red · Basketball: PTS, REB, AST, 3PM, 2PM, FTM, STL, BLK, TO, Fouls · Flag Football: TD, Pass TD, REC, INT, Flag Pulls, Sacks, Catch %
- Live matches update the box score in place off the existing match streams (tallies memoized, never computed in build)
- The Lineup tab is hidden for now (code kept; a positioned-players-on-field version is planned); match tabs spread evenly across the full width with long team names scaling to fit

## Test Plan
- [x] `flutter test` — 964 passing (24 new: column defs/auto-hide/sort, widget tests via Firebase-free seams, tally counters)
- [x] `flutter analyze` — 0 errors, no new warnings
- [x] On-device (release build): futsal league + soccer tournament matches, live update, sorting, profile taps, light+dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)